### PR TITLE
Refactor process_depth

### DIFF
--- a/core/processor.py
+++ b/core/processor.py
@@ -1,17 +1,11 @@
 import logging
-from aiohttp import ClientSession
 
 from config import SLIP_BY_DEPTH
 from core.metrics import g_edge, g_trades, g_pnl
-from connectors import polymarket, sx
 
 
-async def process_depth(
-    session: ClientSession, pm_market: str, sx_market: str
-) -> float:
-    """Fetch depth from both exchanges and determine max slippage."""
-    pm_depth = await polymarket.orderbook_depth(session, pm_market)
-    sx_depth = await sx.orderbook_depth(session, sx_market)
+async def process_depth(pm_depth: float, sx_depth: float) -> float:
+    """Determine max slippage given order book depths from both exchanges."""
     depth_value = min(pm_depth, sx_depth)
 
     max_slip = 0.0

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from aiohttp import ClientSession
 from core.metrics import init_metrics
 from core.alerts import TelegramHandler
 from core.processor import process_depth
+from connectors import polymarket, sx
 
 
 async def main():
@@ -14,7 +15,9 @@ async def main():
 
     async with ClientSession() as session:
         # Example market ids placeholders
-        await process_depth(session, "pm_example", "sx_example")
+        pm_depth = await polymarket.orderbook_depth(session, "pm_example")
+        sx_depth = await sx.orderbook_depth(session, "sx_example")
+        await process_depth(pm_depth, sx_depth)
 
 
 if __name__ == "__main__":

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -9,18 +9,7 @@ sys.path.insert(
 from core import processor  # noqa: E402
 
 
-async def _dummy_pm(*_args, **_kwargs):
-    return 1100
-
-
-async def _dummy_sx(*_args, **_kwargs):
-    return 800
-
-
 @pytest.mark.asyncio
-async def test_process_depth(monkeypatch):
-    monkeypatch.setattr(processor.polymarket, "orderbook_depth", _dummy_pm)
-    monkeypatch.setattr(processor.sx, "orderbook_depth", _dummy_sx)
-
-    result = await processor.process_depth(None, "pm", "sx")
+async def test_process_depth():
+    result = await processor.process_depth(1100, 800)
     assert abs(result - 0.0015) < 1e-6


### PR DESCRIPTION
## Summary
- pass numerical depth values into `process_depth`
- fetch depths in `main` via the connector modules
- adjust processor tests to the new API

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `flake8 .`


------
https://chatgpt.com/codex/tasks/task_e_68669db9f028832f89b553d8cbea0cf8