### PR TITLE
Include details in connector errors

### DIFF
--- a/connectors/polymarket.py
+++ b/connectors/polymarket.py
@@ -44,11 +44,11 @@ async def orderbook_depth(
                 raise OrderbookError(f"status {r.status}")
             data: Any = await r.json()
     except ClientError as exc:
-        raise OrderbookError("request failed") from exc
+        raise OrderbookError(f"request failed: {exc}") from exc
 
     try:
         bids = [float(lvl["quantity"]) for lvl in data["bids"]["Yes"][:depth]]
     except (KeyError, ValueError, TypeError) as exc:
-        raise OrderbookError("bad response format") from exc
+        raise OrderbookError(f"bad response format: {exc}") from exc
 
     return sum(bids)

--- a/connectors/sx.py
+++ b/connectors/sx.py
@@ -44,11 +44,11 @@ async def orderbook_depth(
                 raise SxError(f"status {r.status}")
             data: Any = await r.json()
     except ClientError as exc:
-        raise SxError("request failed") from exc
+        raise SxError(f"request failed: {exc}") from exc
 
     try:
         bids = [float(lvl["quantity"]) for lvl in data["bids"][:depth]]
     except (KeyError, ValueError, TypeError) as exc:
-        raise SxError("bad response format") from exc
+        raise SxError(f"bad response format: {exc}") from exc
 
     return sum(bids)

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -1,0 +1,46 @@
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from connectors import polymarket, sx  # noqa: E402
+
+class DummyResponse:
+    def __init__(self, data, status=200):
+        self._data = data
+        self.status = status
+
+    async def json(self):
+        return self._data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+class DummySession:
+    def __init__(self, data):
+        self._data = data
+
+    def get(self, *args, **kwargs):
+        return DummyResponse(self._data)
+
+@pytest.mark.asyncio
+async def test_polymarket_bad_json():
+    session = DummySession({'foo': 'bar'})
+    with pytest.raises(polymarket.OrderbookError) as excinfo:
+        await polymarket.orderbook_depth(session, 'm')
+    msg = str(excinfo.value)
+    assert 'bad response format' in msg
+    assert 'bids' in msg
+
+@pytest.mark.asyncio
+async def test_sx_bad_json():
+    session = DummySession({'foo': 'bar'})
+    with pytest.raises(sx.SxError) as excinfo:
+        await sx.orderbook_depth(session, 'm')
+    msg = str(excinfo.value)
+    assert 'bad response format' in msg
+    assert 'bids' in msg


### PR DESCRIPTION
## Summary
- improve error messages in `polymarket` and `sx` connectors by attaching the
  original exception
- add tests for malformed JSON to check new error strings

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68669dbbaac4832fadf6fa66cbe016a8