### PR TITLE
Fix PnL gauge reset behavior

### DIFF
--- a/core/metrics.py
+++ b/core/metrics.py
@@ -1,9 +1,21 @@
+"""Prometheus metrics helpers used across the project."""
+
 from prometheus_client import start_http_server, Gauge
 
+# Metrics
 g_edge = Gauge("arb_signal_total", "Signals (edge found)")
 g_trades = Gauge("arb_trades_total", "Executed trade pairs")
-g_pnl = Gauge("arb_cum_pnl_usd", "Cumulative PnL (USDC)")
+g_pnl = Gauge(
+    "arb_cum_pnl_usd",
+    "Cumulative PnL (USDC). This value is not automatically reset between runs.",
+)
 
 
 def init_metrics(port: int = 9090):
+    """Start the Prometheus HTTP metrics server."""
     start_http_server(port)
+
+
+def reset_pnl() -> None:
+    """Reset the cumulative PnL gauge to zero."""
+    g_pnl.set(0.0)

--- a/core/processor.py
+++ b/core/processor.py
@@ -1,7 +1,7 @@
 import logging
 
 from config import SLIP_BY_DEPTH
-from core.metrics import g_edge, g_trades, g_pnl
+from core.metrics import g_edge, g_trades
 
 
 async def process_depth(pm_depth: float, sx_depth: float) -> float:
@@ -16,6 +16,5 @@ async def process_depth(pm_depth: float, sx_depth: float) -> float:
 
     g_edge.inc()
     g_trades.inc()
-    g_pnl.set(0.0)
     logging.info("Depth PM %.2f SX %.2f -> max_slip %.4f", pm_depth, sx_depth, max_slip)
     return max_slip

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -6,6 +6,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 from connectors import polymarket, sx  # noqa: E402
 
+
 class DummyResponse:
     def __init__(self, data, status=200):
         self._data = data
@@ -20,12 +21,14 @@ class DummyResponse:
     async def __aexit__(self, exc_type, exc, tb):
         pass
 
+
 class DummySession:
     def __init__(self, data):
         self._data = data
 
     def get(self, *args, **kwargs):
         return DummyResponse(self._data)
+
 
 @pytest.mark.asyncio
 async def test_polymarket_bad_json():
@@ -35,6 +38,7 @@ async def test_polymarket_bad_json():
     msg = str(excinfo.value)
     assert 'bad response format' in msg
     assert 'bids' in msg
+
 
 @pytest.mark.asyncio
 async def test_sx_bad_json():

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from core.metrics import g_pnl, reset_pnl  # noqa: E402
+from core import processor  # noqa: E402
+
+
+def test_reset_pnl_sets_zero():
+    g_pnl.set(5.5)
+    reset_pnl()
+    assert g_pnl._value.get() == 0.0
+
+
+@pytest.mark.asyncio
+async def test_process_depth_does_not_reset_pnl():
+    g_pnl.set(3.0)
+    await processor.process_depth(1000, 1000)
+    assert g_pnl._value.get() == 3.0


### PR DESCRIPTION
## Summary
- avoid clearing PnL gauge on each depth processing
- add `reset_pnl` helper and document metric usage
- clean up test files
- test new `reset_pnl` behaviour

## Testing
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c49b0e00832f98f657507d1d1c06