### PR TITLE
Add type hints and mypy config

### DIFF
--- a/core/alerts.py
+++ b/core/alerts.py
@@ -8,22 +8,24 @@ CHAT = int(os.getenv("TELEGRAM_CHAT_ID", "0"))
 
 
 class TelegramHandler(logging.Handler):
-    def __init__(self, level=logging.ERROR):
+    def __init__(self, level: int = logging.ERROR) -> None:
         super().__init__(level)
-        self.bot = Bot(TOKEN) if TOKEN else None
+        self.bot: Bot | None = Bot(TOKEN) if TOKEN else None
 
-    def emit(self, record):
+    def emit(self, record: logging.LogRecord) -> None:
         if not self.bot or not CHAT:
             return
+        bot = self.bot
+        assert bot is not None
         msg = f"\u26a0\ufe0f {record.levelname}: {record.getMessage()[:350]}"
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
             return
 
-        async def _send():
+        async def _send() -> None:
             try:
-                await self.bot.send_message(chat_id=CHAT, text=msg)
+                await bot.send_message(chat_id=CHAT, text=msg)
             except Exception:
                 logging.exception("Failed to send Telegram message")
 

--- a/core/matcher.py
+++ b/core/matcher.py
@@ -1,4 +1,6 @@
 from rapidfuzz import fuzz
+from collections.abc import Sequence
+from typing import Any
 
 
 def _normalize(s: str) -> str:
@@ -13,8 +15,10 @@ def _extract_teams(title: str) -> tuple[str, str]:
     return (_normalize(title), "")
 
 
-def match(pm_list, sx_list, min_score: int = 87):
-    pairs = []
+def match(
+    pm_list: Sequence[Any], sx_list: Sequence[Any], min_score: int = 87
+) -> list[tuple[Any, Any]]:
+    pairs: list[tuple[Any, Any]] = []
     sx_index = {_normalize(x.title): x for x in sx_list}
 
     for pm in pm_list:

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from core.processor import process_depth
 from connectors import polymarket, sx
 
 
-async def main():
+async def main() -> None:
     logging.basicConfig(level=logging.INFO)
     logging.getLogger().addHandler(TelegramHandler())
     init_metrics()

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,8 @@
 max-line-length = 100
 extend-select = B, C, E, F, W
 exclude = .git,__pycache__,build,dist
+
+[mypy]
+ignore_missing_imports = True
+explicit_package_bases = True
+files = core,connectors,main.py


### PR DESCRIPTION
## Summary
- type annotate alerts, matcher, and main functions
- configure mypy for the project

## Testing
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c507e468832fbbb229ea0e937e5f