### PR TITLE
Format tests with black

### DIFF
--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -5,7 +5,9 @@ import importlib
 import asyncio
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))  # noqa: E402
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)  # noqa: E402
 
 import core.alerts as alerts  # noqa: E402
 

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -2,7 +2,7 @@ import sys
 import os
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from connectors import polymarket, sx  # noqa: E402
 
@@ -32,19 +32,19 @@ class DummySession:
 
 @pytest.mark.asyncio
 async def test_polymarket_bad_json():
-    session = DummySession({'foo': 'bar'})
+    session = DummySession({"foo": "bar"})
     with pytest.raises(polymarket.OrderbookError) as excinfo:
-        await polymarket.orderbook_depth(session, 'm')
+        await polymarket.orderbook_depth(session, "m")
     msg = str(excinfo.value)
-    assert 'bad response format' in msg
-    assert 'bids' in msg
+    assert "bad response format" in msg
+    assert "bids" in msg
 
 
 @pytest.mark.asyncio
 async def test_sx_bad_json():
-    session = DummySession({'foo': 'bar'})
+    session = DummySession({"foo": "bar"})
     with pytest.raises(sx.SxError) as excinfo:
-        await sx.orderbook_depth(session, 'm')
+        await sx.orderbook_depth(session, "m")
     msg = str(excinfo.value)
-    assert 'bad response format' in msg
-    assert 'bids' in msg
+    assert "bad response format" in msg
+    assert "bids" in msg

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,7 +2,7 @@ import os
 import sys
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from core.metrics import g_pnl, reset_pnl  # noqa: E402
 from core import processor  # noqa: E402


### PR DESCRIPTION
## Summary
- reformat tests with black for consistency

## Testing
- `black --check .`

------
https://chatgpt.com/codex/tasks/task_e_686aa9ae75ec832fa11c6f6380df7b80