### PR TITLE
Add retry utility decorator

### DIFF
--- a/connectors/polymarket.py
+++ b/connectors/polymarket.py
@@ -5,30 +5,13 @@ from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientError
 from typing import Any
 
+from utils.retry import retry
+
 API_CLOB = "https://polymarket.com/api"
 
 
 class OrderbookError(Exception):
     """Raised when order book data cannot be retrieved or parsed."""
-
-
-def retry(attempts: int = 3, delay: float = 1.0):
-    def decorator(func):
-        async def wrapper(*args, **kwargs):
-            for i in range(attempts):
-                try:
-                    return await func(*args, **kwargs)
-                except Exception as exc:
-                    logging.debug(
-                        "Attempt %s/%s failed: %s", i + 1, attempts, exc, exc_info=True
-                    )
-                    if i == attempts - 1:
-                        raise
-                    await asyncio.sleep(delay)
-
-        return wrapper
-
-    return decorator
 
 
 @retry()

--- a/connectors/sx.py
+++ b/connectors/sx.py
@@ -5,30 +5,13 @@ from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientError
 from typing import Any
 
+from utils.retry import retry
+
 API_REST = "https://api.sx.bet"
 
 
 class SxError(Exception):
     """Raised when SX API responses are invalid."""
-
-
-def retry(attempts: int = 3, delay: float = 1.0):
-    def decorator(func):
-        async def wrapper(*args, **kwargs):
-            for i in range(attempts):
-                try:
-                    return await func(*args, **kwargs)
-                except Exception as exc:
-                    logging.debug(
-                        "Attempt %s/%s failed: %s", i + 1, attempts, exc, exc_info=True
-                    )
-                    if i == attempts - 1:
-                        raise
-                    await asyncio.sleep(delay)
-
-        return wrapper
-
-    return decorator
 
 
 @retry()

--- a/utils/retry.py
+++ b/utils/retry.py
@@ -1,0 +1,25 @@
+import asyncio
+import logging
+from typing import Callable, Coroutine, TypeVar, Any
+
+F = TypeVar("F", bound=Callable[..., Coroutine[Any, Any, Any]])
+
+def retry(attempts: int = 3, delay: float = 1.0):
+    """Retry an async function multiple times with a delay."""
+
+    def decorator(func: F) -> F:
+        async def wrapper(*args, **kwargs):
+            for i in range(attempts):
+                try:
+                    return await func(*args, **kwargs)
+                except Exception as exc:  # pragma: no cover - logging
+                    logging.debug(
+                        "Attempt %s/%s failed: %s", i + 1, attempts, exc, exc_info=True
+                    )
+                    if i == attempts - 1:
+                        raise
+                    await asyncio.sleep(delay)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator


### PR DESCRIPTION
## Summary
- factor out async retry decorator to utils module
- use the shared retry decorator in `connectors/polymarket.py` and `connectors/sx.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aa9af1900832fa4f988ae937cc244