### PR TITLE
Fix empty dictionary initialization crash

### DIFF
--- a/core/processor.py
+++ b/core/processor.py
@@ -9,7 +9,8 @@ async def process_depth(pm_depth: float, sx_depth: float) -> float:
     depth_value = min(pm_depth, sx_depth)
 
     # Default to highest slippage if depth is below all thresholds
-    max_slip = max(SLIP_BY_DEPTH.values())
+    # Handle empty dictionary case by defaulting to 0.0
+    max_slip = max(SLIP_BY_DEPTH.values()) if SLIP_BY_DEPTH else 0.0
     for d, slip in sorted(SLIP_BY_DEPTH.items(), reverse=True):
         if depth_value >= d:
             max_slip = slip

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -13,3 +13,21 @@ from core import processor  # noqa: E402
 async def test_process_depth():
     result = await processor.process_depth(1100, 800)
     assert abs(result - 0.0015) < 1e-6
+
+
+@pytest.mark.asyncio
+async def test_process_depth_empty_config():
+    """Test that process_depth handles empty SLIP_BY_DEPTH gracefully."""
+    # Save original config
+    original_slip_by_depth = processor.SLIP_BY_DEPTH
+    
+    try:
+        # Set empty dictionary
+        processor.SLIP_BY_DEPTH = {}
+        
+        # Should not raise ValueError and should return 0.0
+        result = await processor.process_depth(1100, 800)
+        assert result == 0.0
+    finally:
+        # Restore original config
+        processor.SLIP_BY_DEPTH = original_slip_by_depth


### PR DESCRIPTION
Handle empty `SLIP_BY_DEPTH` dictionary to prevent `ValueError` and runtime crash.

Previously, `max(SLIP_BY_DEPTH.values())` would raise a `ValueError` if `SLIP_BY_DEPTH` was empty, causing a crash. This change ensures `max_slip` defaults to 0.0 in such cases, restoring the intended safe behavior.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-e7a04bc2-e736-4905-8539-1df8ad03dada) · [Cursor](https://cursor.com/background-agent?bcId=bc-e7a04bc2-e736-4905-8539-1df8ad03dada)