### PR TITLE
Update process_depth argument types

### DIFF
--- a/core/processor.py
+++ b/core/processor.py
@@ -12,12 +12,8 @@ def calculate_total_depth(orderbook: Dict[str, List[Dict]]) -> float:
     return total_bids + total_asks
 
 
-async def process_depth(pm_orderbook: Dict, sx_orderbook: Dict) -> float:
+async def process_depth(pm_depth: float, sx_depth: float) -> float:
     """Определяем максимальное проскальзывание на основе глубины стакана с обеих бирж."""
-    
-    # Вычисляем общую глубину для каждой биржи
-    pm_depth = calculate_total_depth(pm_orderbook)
-    sx_depth = calculate_total_depth(sx_orderbook)
     
     # Берем минимальную глубину (лимитирующий фактор)
     depth_value = min(pm_depth, sx_depth)

--- a/demo_bot.py
+++ b/demo_bot.py
@@ -135,6 +135,12 @@ def print_depth_analysis(pm_depth: Dict, sx_depth: Dict) -> None:
     print(f"   Polymarket: {pm_spread:.4f} ({pm_spread*100:.2f}%)")
     print(f"   SX: {sx_spread:.4f} ({sx_spread*100:.2f}%)")
 
+def calculate_total_depth(orderbook: Dict) -> float:
+    """Вычисляем общую глубину стакана"""
+    total_bids = sum(order["size"] for order in orderbook.get("bids", []))
+    total_asks = sum(order["size"] for order in orderbook.get("asks", []))
+    return total_bids + total_asks
+
 async def demo_cycle(cycle_num: int) -> None:
     """Выполняем один демо-цикл"""
     print(f"\n🔄 ЦИКЛ #{cycle_num}")
@@ -146,9 +152,15 @@ async def demo_cycle(cycle_num: int) -> None:
     # Выводим анализ
     print_depth_analysis(pm_depth, sx_depth)
     
+    # Вычисляем общую глубину для каждой биржи
+    pm_total_depth = calculate_total_depth(pm_depth)
+    sx_total_depth = calculate_total_depth(sx_depth)
+    
     # Обрабатываем данные через основную логику бота
     print(f"\n⚙️ Обработка данных...")
-    await process_depth(pm_depth, sx_depth)
+    print(f"   Общая глубина Polymarket: {pm_total_depth:.0f}")
+    print(f"   Общая глубина SX: {sx_total_depth:.0f}")
+    await process_depth(pm_total_depth, sx_total_depth)
     
     print(f"✅ Цикл #{cycle_num} завершен")
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -18,15 +18,9 @@ def test_reset_pnl_sets_zero():
 async def test_process_depth_does_not_reset_pnl():
     g_pnl.set(3.0)
     
-    # Создаем моковые данные стакана
-    pm_orderbook = {
-        "bids": [{"price": 0.65, "size": 1000}],
-        "asks": [{"price": 0.66, "size": 1000}]
-    }
-    sx_orderbook = {
-        "bids": [{"price": 0.65, "size": 1000}],
-        "asks": [{"price": 0.66, "size": 1000}]
-    }
+    # Тестируем с числовыми значениями глубины
+    pm_depth = 2000.0  # 1000 + 1000
+    sx_depth = 2000.0  # 1000 + 1000
     
-    await processor.process_depth(pm_orderbook, sx_orderbook)
+    await processor.process_depth(pm_depth, sx_depth)
     assert g_pnl._value.get() == 3.0

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -11,18 +11,12 @@ from core import processor  # noqa: E402
 
 @pytest.mark.asyncio
 async def test_process_depth():
-    # Создаем моковые данные стакана
-    pm_orderbook = {
-        "bids": [{"price": 0.65, "size": 1100}],
-        "asks": [{"price": 0.66, "size": 800}]
-    }
-    sx_orderbook = {
-        "bids": [{"price": 0.65, "size": 800}],
-        "asks": [{"price": 0.66, "size": 1100}]
-    }
+    # Тестируем с числовыми значениями глубины
+    pm_depth = 1900.0  # 1100 + 800
+    sx_depth = 1900.0  # 800 + 1100
     
-    result = await processor.process_depth(pm_orderbook, sx_orderbook)
-    assert abs(result - 0.0010) < 1e-6  # Ожидаем проскальзывание для глубины 800
+    result = await processor.process_depth(pm_depth, sx_depth)
+    assert abs(result - 0.0010) < 1e-6  # Ожидаем проскальзывание для глубины 1900
 
 
 @pytest.mark.asyncio
@@ -35,18 +29,12 @@ async def test_process_depth_empty_config():
         # Set empty dictionary
         processor.SLIP_BY_DEPTH = {}
         
-        # Создаем моковые данные стакана
-        pm_orderbook = {
-            "bids": [{"price": 0.65, "size": 1100}],
-            "asks": [{"price": 0.66, "size": 800}]
-        }
-        sx_orderbook = {
-            "bids": [{"price": 0.65, "size": 800}],
-            "asks": [{"price": 0.66, "size": 1100}]
-        }
+        # Тестируем с числовыми значениями глубины
+        pm_depth = 1900.0
+        sx_depth = 1900.0
         
         # Should not raise ValueError and should return 0.0
-        result = await processor.process_depth(pm_orderbook, sx_orderbook)
+        result = await processor.process_depth(pm_depth, sx_depth)
         assert result == 0.0
     finally:
         # Restore original config


### PR DESCRIPTION
Refactor `process_depth` to accept float values directly, resolving a TypeError from argument mismatch.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-00c77f5d-f64e-466e-a88e-67c28ca15cbf) · [Cursor](https://cursor.com/background-agent?bcId=bc-00c77f5d-f64e-466e-a88e-67c28ca15cbf)